### PR TITLE
Ref latest aws docs

### DIFF
--- a/00-dev-environment/README.md
+++ b/00-dev-environment/README.md
@@ -51,8 +51,8 @@ MFA.  You won't be able to retrieve your token if the access key and secret key 
 credentials file. You will need to [install the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html)
 and then run some simple commands to confirm access using your keys:
 
-- [list-buckets](https://docs.aws.amazon.com/cli/latest/reference/s3api/list-buckets.html)
-- [describe-instances](https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-instances.html)
+- [list-buckets](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/s3api/list-buckets.html)
+- [describe-instances](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ec2/describe-instances.html)
 
 Remember that the combination of an access key and a secret key are
 the same as user credentials and should not be given out or stored

--- a/00-dev-environment/README.md
+++ b/00-dev-environment/README.md
@@ -46,9 +46,11 @@ GitHub code repositories, and, optionally, AWS Cloud9 for your development envir
 
 #### Lab 0.1.1: AWS Access Keys
 
-Save your AWS access key and secret key to a private credentials file on your laptop before enabling
-MFA.  You won't be able to retrieve your token if the access key and secret key are not added to your
-credentials file. You will need to [install the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html)
+Save your AWS access key and secret key to a private credentials file
+on your laptop before enabling MFA.  You won't be able to retrieve your
+token if the access key and secret key are not added to your credentials
+file. You will need to
+[install the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html)
 and then run some simple commands to confirm access using your keys:
 
 - [list-buckets](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/s3api/list-buckets.html)

--- a/00-dev-environment/README.md
+++ b/00-dev-environment/README.md
@@ -46,8 +46,8 @@ GitHub code repositories, and, optionally, AWS Cloud9 for your development envir
 
 #### Lab 0.1.1: AWS Access Keys
 
-Save your AWS access key and secret key to a private credentials file on your laptop before enabling 
-MFA.  You won't be able to retrieve your token if the access key and secret key are not added to your 
+Save your AWS access key and secret key to a private credentials file on your laptop before enabling
+MFA.  You won't be able to retrieve your token if the access key and secret key are not added to your
 credentials file. You will need to [install the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html)
 and then run some simple commands to confirm access using your keys:
 
@@ -58,7 +58,7 @@ Remember that the combination of an access key and a secret key are
 the same as user credentials and should not be given out or stored
 in a public location like a GitHub repository, nor should they be
 transmitted in an insecure manner like unencrypted email.
-_Never_ commit credentials to a git repo.
+*Never* commit credentials to a git repo.
 
 - [Enable MFA](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa_enable_virtual.html)
   for your AWS account. With MFA enabled you will need to generate temporary

--- a/01-cloudformation/README.md
+++ b/01-cloudformation/README.md
@@ -51,7 +51,7 @@
 - DO utilize every link in this document; note how the AWS documentation is
   laid out
 
-- DO use the [AWS CLI for CloudFormation](https://docs.aws.amazon.com/cli/latest/reference/cloudformation/index.html#)
+- DO use the [AWS CLI for CloudFormation](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/cloudformation/index.html#)
   (NOT the Console) unless otherwise specified.
 
 ## Lesson 1.1: Introduction to CloudFormation
@@ -80,7 +80,7 @@ create an AWS Simple Storage Service (S3) Bucket.
 
 - Always write your CloudFormation [templates in YAML](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-formats.html).
 
-- Launch a Stack by [using the AWS CLI tool](https://docs.aws.amazon.com/cli/latest/reference/cloudformation/create-stack.html)
+- Launch a Stack by [using the AWS CLI tool](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/cloudformation/create-stack.html)
   to run the template. Use your preferred region.
 
 - Note the output provided by creating the Stack.

--- a/02-s3/README.md
+++ b/02-s3/README.md
@@ -92,7 +92,7 @@ line.
 
 You created S3 buckets with CloudFormation in the [first lesson](https://drive.google.com/open?id=10Y8lCLTi-gg_R4PV9hEBCVPTmsOwem60nRtr8zq1264)
 in this series. In this practice session, we'll get familiar with the
-[awscli's s3 command](https://docs.aws.amazon.com/cli/latest/reference/s3/).
+[awscli's s3 command](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/s3/index.html).
 
 #### Lab 2.1.1: Create a Bucket
 
@@ -144,7 +144,7 @@ bucket again **without including the private file**.
 - Verify after uploading that the file doesn't exist in the bucket.
 
 - Did you find two different ways to accomplish this task? If not, make sure to
-  read the [documentation on sync flags](https://docs.aws.amazon.com/cli/latest/reference/s3/sync.html).
+  read the [documentation on sync flags](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/s3/sync.html).
 
 #### Lab 2.1.4: Clean Up
 
@@ -154,7 +154,7 @@ remove it?
 ### Retrospective 2.1
 
 For additional s3 commands and reference see the
-[AWS CLI Command Reference](https://docs.aws.amazon.com/cli/latest/reference/s3/)
+[AWS CLI Command Reference](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/s3/index.html)
 
 ## Lesson 2.2: Intro to S3 Permissions
 

--- a/14-Jenkins/README.md
+++ b/14-Jenkins/README.md
@@ -81,10 +81,10 @@ to do this you will need the following:
 You may work off of the provided `base.yaml` template.
 
 Once you have created the CloudFormation template, launch it and navigate
-to the Jenkins instance when complete. Install Jenkins on the EC2 instance, 
-and starting the service. Finally, following the admin install wizard by 
-navigating to the instance IP at the correct port. Verify that Jenkins is 
-set up and ready for use by ensuring the "Welcome to Jenkins!" prompt is 
+to the Jenkins instance when complete. Install Jenkins on the EC2 instance,
+and starting the service. Finally, following the admin install wizard by
+navigating to the instance IP at the correct port. Verify that Jenkins is
+set up and ready for use by ensuring the "Welcome to Jenkins!" prompt is
 present and you can:
 
 - Add a "New Item"


### PR DESCRIPTION
# Requirements for Contributing a Bug Fix

- Fill out the template below. Any pull request that does not include enough
  information to be reviewed in a timely manner may be closed at the maintainers'
  discretion.

## Identify the Bug

There are several occurrences when  Initial chapters of Stelligent guidelines referred to the old AWS CLI docs

## Description of the Change

- Initial chapters of Stelligent guidelines referred to the old AWS CLI docs. Those occurrences were changed with references to AWS CLI v2 docs.
- Several errors, discovered with built-in lint verification process, were fixed

## Alternate Designs

N/A

## Possible Drawbacks

N/A

## Verification Process

GitHub Actions workflow defines the testing process, involving lint routine

## Release Notes

Initial chapters of Stelligent guidelines now refer to the latest v2 docs for AWS CLI.